### PR TITLE
Build CARE with self-extracting support

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+care (2.2.1-2) unstable; urgency=low
+
+  * Enable self-extracting archives
+
+ -- Pierre Schweitzer <pierre@reactos.org>  Thu, 30 Jul 2015 15:10:05 +0200
+
 care (2.2.1-1) unstable; urgency=low
 
   * Initial release (Closes: #779349)

--- a/rules
+++ b/rules
@@ -1,5 +1,8 @@
 #!/usr/bin/make -f
 # -*- makefile -*-
+
+export DEB_CPPFLAGS_MAINT_APPEND = -DCARE_BINARY_IS_PORTABLE
+
 %:
 	dh $@ --sourcedirectory=src
 


### PR DESCRIPTION
This is a pull request matching Debian Bug #794070 (same patch and features).

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=794070
